### PR TITLE
Update to support sos 3.4

### DIFF
--- a/iml_sos_plugin/iml.py
+++ b/iml_sos_plugin/iml.py
@@ -31,8 +31,7 @@ class IML(Plugin, RedHatPlugin):
                 "/var/log/chroma-agent*.log",
             ]
 
-        copy_globs = copy_globs + \
-            ["/var/lib/chroma/settings/*", "/var/lib/chroma/targets/*"]
+        copy_globs += ["/var/lib/chroma/settings/*", "/var/lib/chroma/targets/*"]
 
         self.add_copy_spec(copy_globs, sizelimit=limit)
 

--- a/iml_sos_plugin/iml.py
+++ b/iml_sos_plugin/iml.py
@@ -31,9 +31,10 @@ class IML(Plugin, RedHatPlugin):
                 "/var/log/chroma-agent*.log",
             ]
 
-        copy_globs = copy_globs + ["/var/lib/chroma/settings/*", "/var/lib/chroma/targets/*"]
+        copy_globs = copy_globs + \
+            ["/var/lib/chroma/settings/*", "/var/lib/chroma/targets/*"]
 
-        [self.add_copy_spec_limit(x, sizelimit=limit) for x in copy_globs]
+        self.add_copy_spec(copy_globs, sizelimit=limit)
 
         self.add_cmd_output([
             'chroma-agent device_plugin --plugin=linux',


### PR DESCRIPTION
sos 3.4 removed `add_copy_spec_limit` and replaced it with just `add_copy_spec`.