### PR TITLE
Stop tailing by default

### DIFF
--- a/iml_sos_plugin/cli.py
+++ b/iml_sos_plugin/cli.py
@@ -27,7 +27,7 @@ def main():
         "yum",
     ]
 
-    code = call(["sosreport"] + args + ["--batch"] +
+    code = call(["sosreport"] + args + ["--batch", "--log_size=0"] +
                 list(flat_map(lambda x: ["--only", x], plugins)))
 
     sys.exit(code)

--- a/iml_sos_plugin/cli.py
+++ b/iml_sos_plugin/cli.py
@@ -23,7 +23,8 @@ def main():
         "processor",
         "memory",
         "filesys",
-        "block"
+        "block",
+        "yum",
     ]
 
     code = call(["sosreport"] + args + ["--batch"] +

--- a/iml_sos_plugin/iml.py
+++ b/iml_sos_plugin/iml.py
@@ -17,8 +17,9 @@ class IML(Plugin, RedHatPlugin):
     requires_root = True
 
     def setup(self):
-        limit = self.get_option("log_size", default=0)
+        limit = self.get_option("log_size", default=None)
         all_logs = self.get_option("all_logs", default=False)
+        tailit = self.get_option("tailit", default=False)
 
         if all_logs:
             copy_globs = [
@@ -33,7 +34,7 @@ class IML(Plugin, RedHatPlugin):
 
         copy_globs += ["/var/lib/chroma/settings/*", "/var/lib/chroma/targets/*"]
 
-        self.add_copy_spec(copy_globs, sizelimit=limit)
+        self.add_copy_spec(copy_globs, sizelimit=limit, tailit=tailit)
 
         self.add_cmd_output([
             'chroma-agent device_plugin --plugin=linux',


### PR DESCRIPTION
Our chroma-agent.log is currently getting tailed to the last 10MB.

Update the default so it doesn't tail and add an override to the plugin.

In addition add the yum plugin to iml-diagnostics.