### PR TITLE
GH-374 Chroma-Diagnostics needs to be obsolete

### DIFF
--- a/iml_sos_plugin/cli.py
+++ b/iml_sos_plugin/cli.py
@@ -32,3 +32,6 @@ def main():
                 list(flat_map(lambda x: ["--only", x], plugins)))
 
     sys.exit(code)
+
+def chroma_diagnostics():
+    print "chroma-diagnostics no longer exists. Please use 'iml-diagnostics' instead."

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     entry_points={
         'console_scripts': [
             'iml-diagnostics = iml_sos_plugin.cli:main',
+            'chroma-diagnostics = iml_sos_plugin.cli:chroma_diagnostics'
         ]
     }
 )


### PR DESCRIPTION
- Add a new entry script such that when a user enteres the
  "chroma-diagnostics" command a message will display indicating the
  chroma-diagnostics is obsolete.

Signed-off-by: Will Johnson <william.c1.johnson@gmail.com>