### PR TITLE
- Remove zfs plugin for the time being as it is not shipped in sos yet.

### DIFF
--- a/iml_sos_plugin/cli.py
+++ b/iml_sos_plugin/cli.py
@@ -25,7 +25,6 @@ def main():
         "filesys",
         "block",
         "yum",
-        "zfs",
     ]
 
     code = call(["sosreport"] + args + ["--batch", "--log-size=0"] +


### PR DESCRIPTION
When running iml-diagnostics with the zfs plugin we get the following:
```
[root@adm iml-4.0.0.0]# iml-diagnostics

sosreport (version 3.4)

a non-existing plugin (zfs) was specified in the command line
```

This is because the zfs plugin is not shipped with sos. For now, it needs to be removed.